### PR TITLE
Include 1080p hash in the upload form

### DIFF
--- a/client/views/pages/upload/upload.js
+++ b/client/views/pages/upload/upload.js
@@ -114,8 +114,8 @@ Template.upload.genBody = function (author, permlink, title, snaphash, videohash
 
 Template.upload.uploadVideo = function (file, progressid, cb) {
   var postUrl = (Session.get('remoteSettings').localhost == true)
-    ? 'http://localhost:5000/uploadVideo?videoEncodingFormats=240p,480p,720p&sprite=true'
-    : 'https://'+Session.get('upldr')+'.d.tube/uploadVideo?videoEncodingFormats=240p,480p,720p&sprite=true'
+    ? 'http://localhost:5000/uploadVideo?videoEncodingFormats=240p,480p,720p,1080p&sprite=true'
+    : 'https://'+Session.get('upldr')+'.d.tube/uploadVideo?videoEncodingFormats=240p,480p,720p,1080p&sprite=true'
   var formData = new FormData();
   formData.append('files', file);
   $(progressid).progress({ value: 0, total: 1 })

--- a/client/views/pages/upload/uploadform/uploadform.js
+++ b/client/views/pages/upload/uploadform/uploadform.js
@@ -97,8 +97,8 @@ Template.uploadform.generateVideo = function (tags) {
     article.content.video480hash = $('input[name=video480hash]')[0].value
   if ($('input[name=video720hash]')[0].value.length > 0)
     article.content.video720hash = $('input[name=video720hash]')[0].value
-  // if ($('input[name=video1080hash]')[0].value.length > 0)
-  //   article.content.video1080hash = $('input[name=video1080hash]')[0].value
+  if ($('input[name=video1080hash]')[0].value.length > 0)
+    article.content.video1080hash = $('input[name=video1080hash]')[0].value
   if ($('input[name=magnet]')[0].value.length > 0)
     article.content.magnet = $('input[name=magnet]')[0].value
 

--- a/client/views/pages/upload/uploadform/uploadformadvanced.html
+++ b/client/views/pages/upload/uploadform/uploadformadvanced.html
@@ -40,6 +40,12 @@
           </label>
           <input type="text" name="video720hash" placeholder="{{ translate 'UPLOAD_VIDEO720HASH'}}" value="{{content.video720hash}}">
         </div>
+        <div class="field">
+          <label>{{ translate 'UPLOAD_VIDEO1080HASH'}}
+            <i class="external icon"></i>
+          </label>
+          <input type="text" name="video1080hash" placeholder="{{ translate 'UPLOAD_VIDEO1080HASH'}}" value="{{content.video1080hash}}">
+        </div>
       </div>
       <div class="two fields">
         <div class="field">


### PR DESCRIPTION
Include the option for the 1080p hash in the upload form. Also make the site request this format in the URL, which the IPFS Uploader can accept or deny based on its configuration.