### PR TITLE
Set babel/runtime version to 7.0.0-beta.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "desktop": "meteor-desktop"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.55",
+    "@babel/runtime": "7.0.0-beta.55",
     "@trust/webcrypto": "^0.9.0",
     "asksteem": "0.0.12",
     "bufferutil": "^3.0.5",


### PR DESCRIPTION
Put babel/runtime to specific version 7.0.0-beta.55, as other versions may break with meteor

https://forums.meteor.com/t/solved-cannot-find-module-babel-runtime-helpers-builtin-objectspread-after-update-meteor-to-1-6-1-1/43034