### PR TITLE
fix empty notifications

### DIFF
--- a/client/views/topbar/notificationdropdown/notification/notification.html
+++ b/client/views/topbar/notificationdropdown/notification/notification.html
@@ -6,6 +6,22 @@
           <i class="remove circle icon notificationremove"></i>
         </div>
       {{/unless}}
+      {{#if equals tx.type '1'}}
+        <a class='notification-link' href="/c/{{tx.sender}}">
+          <div class="dsp-flx" style="padding:10px;">
+            <img class="ui avatar image" src="{{userPic tx.sender}}">
+            <div style="width: 100%;display: inline;margin-left: 5px;">
+              <div>
+                <span style="color:#ff1a1a!important;" class="user">
+                  {{tx.sender}}
+                </span>
+                voted for you as chain leader
+              </div>
+              <span class="crd-spa-lab">{{timeAgoReal ts}}</span>
+            </div>
+          </div>
+        </a>
+      {{/if}}
       {{#if equals tx.type '7'}}
         <a class='notification-link' href="/c/{{tx.sender}}">
           <div class="dsp-flx" style="padding:10px;">
@@ -41,14 +57,14 @@
             </div>
           </a>
         {{else}}
-          <a class='notification-link' href="/v/{{author}}/{{tx.data.link}}">
+          <a class='notification-link' href="/v/{{tx.sender}}/{{tx.data.link}}">
             <div style="padding: 10px;">
               <div class="dsp-flx">
-                <img class="ui avatar image" src="{{userPic author}}">
+                <img class="ui avatar image" src="{{userPic tx.sender}}">
                 <div style="width: 100%;display: inline;margin-left: 5px;">
                   <div>
                     <span style="color:#ff1a1a!important;" class="user">
-                      {{author}}
+                      {{tx.sender}}
                     </span>
                     mentioned you
                   </div>
@@ -58,6 +74,24 @@
             </div>
           </a>
         {{/if}}
+      {{/if}}
+      {{#if equals tx.type '13'}}
+        <a class='notification-link' href="/v/{{tx.sender}}/{{tx.data.link}}">
+          <div style="padding: 10px;">
+            <div class="dsp-flx">
+              <img class="ui avatar image" src="{{userPic tx.sender}}">
+              <div style="width: 100%;display: inline;margin-left: 5px;">
+                <div>
+                  <span style="color:#ff1a1a!important;" class="user">
+                    {{tx.sender}}
+                  </span>
+                  mentioned you in a promoted post
+                </div>
+                <div><span class="crd-spa-lab">{{timeAgoReal ts}}</span></div>
+              </div>
+            </div>
+          </div>
+        </a>
       {{/if}}
       {{#if equals tx.type '3'}}
         <a class='notification-link' href="/c/{{tx.sender}}">


### PR DESCRIPTION
This fixes the following notifications:
- Mentions
- Mentions on promoted posts
- Leader votes

#### Before

<img width="417" alt="Screenshot 2019-07-16 at 12 35 28 PM" src="https://user-images.githubusercontent.com/37140751/61268355-b9de5200-a7cd-11e9-922c-451e9dbd5adc.png">

#### After

<img width="414" alt="Screenshot 2019-07-16 at 12 36 03 PM" src="https://user-images.githubusercontent.com/37140751/61268393-d9757a80-a7cd-11e9-9e18-981319f12789.png">