### PR TITLE
"Hay un" > "Hay" in Spanish translation

### DIFF
--- a/public/DTube_files/lang/es-ES/es-ES.json
+++ b/public/DTube_files/lang/es-ES/es-ES.json
@@ -62,7 +62,7 @@
     "LOGIN_ERROR_AUTHENTIFICATION_FAILED": "Usuario y Clave Privada de Publicación no corresponden",
     "LOGIN_ERROR_ALREADY_LOGGED": "Ya estás logueado con esa cuenta",
     "SEARCH_RESULTS_FOR": "para",
-    "SEARCH_RESULTS_THERE_IS": "Hay un",
+    "SEARCH_RESULTS_THERE_IS": "Hay",
     "SEARCH_ABOUT": "Acerca",
     "SEARCH_RESULT": "resultado",
     "SEARCH_RESULTS": "resultados",


### PR DESCRIPTION
In Spanish, "There is/are" is translated into one single word, "Hay".