### PR TITLE
fix overlapping settings dropdown menu

### DIFF
--- a/client/css/custom.css
+++ b/client/css/custom.css
@@ -201,3 +201,8 @@ textarea {
  .ui.labeled.icon.buttons > .button > .icon, .ui.labeled.icon.button > .icon{
    line-height: 0!important;
  }
+
+ .ui.dropdown .menu .left.menu {
+  left: auto !important;
+  right: 100% !important;
+}


### PR DESCRIPTION
This overwrites the semantic UI CSS in `custom.css` to force the dropdown to render on the left by appending `!important`.