### PR TITLE
Adding video tags/genres for quick exploration.

### DIFF
--- a/client/collections/videos.js
+++ b/client/collections/videos.js
@@ -841,6 +841,147 @@ Videos.getOverlayUrl = function(video) {
     return ''
 }
 
+Videos.getGenreList = function() {
+    var genreList = ["art", "fashion", "music", "gaming", "food", "travel", "sports",
+                  "talks", "vlog", "science", "documentary", "movies", "journalism", "activism", "diyhub", "other", "original"]
+
+    return genreList
+}
+
+Videos.getGenres = function() {
+    genreUrlMap = Videos.getAllGenreThumbnailUrls()
+
+    var genreThumbnailUrls = $.map(genreUrlMap, function(value, key) { return value });
+    var genreNames = $.map(genreUrlMap, function(value, key) { return key });
+
+    var genres = []
+    for(var g=0; g<genreNames.length; g++) {
+        var genre = {}
+        var json = {}
+        // genre["author"] = "t"
+        // genre["link"] = genreNames[g]
+        json["genreName"] = genreNames[g]
+        json["thumbnailUrl"] = genreThumbnailUrls[g]
+        genre["json"] = json
+        genres.push(genre)
+    }
+    console.log(genres)
+    return genres
+}
+
+Videos.getAllGenreImageFileNames = function() {
+    var allGenreImageFileNames = []
+    var fileNames = []
+
+    // Free image sources: https://unsplash.com/s/photos
+    // may be possible to programmatically lsdir and find too
+
+    // genre_1 art
+    fileNames = ["genre_1_art_1.jpg", "genre_1_art_2_paintings.jpg", "genre_1_art_3_colors.jpg", "genre_1_art_4_brushes.jpg", "genre_1_art_5_painting.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_2 food
+    fileNames = ["genre_2_fashion_1_clothings_black_blue.jpg", "genre_2_fashion_2_fashion_vlogging.jpg", "genre_2_fashion_3_girl_with_blue_dress.jpg", "genre_2_fashion_4_man_with_tshirt.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_3 music
+    fileNames = ["genre_3_music_1_instruments_empty_room.jpg", "genre_3_music_2_concert.jpg", "genre_3_music_3_singer.jpg", "genre_3_music_4_guitarist.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_4 gaming
+    fileNames = ["genre_4_gaming_1_gamer_lightings.jpg", "genre_4_gaming_2_gamer_girl.jpg", "genre_4_gaming_3_joystick.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_5 food
+    fileNames = ["genre_5_food_1_egg_avocado.jpg", "genre_5_food_2_vegetables.jpg", "genre_5_food_3_steak.jpg", "genre_5_food_4_bowl.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_6 travel
+    fileNames = ["genre_6_travel_1_aeroplane.jpg", "genre_6_travel_2_boat_river.jpg", "genre_6_travel_3_balloons.jpg", "genre_6_travel_4_mountain_lake.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_7 sports
+    fileNames = ["genre_7_sports_1_soccer_ball.jpg", "genre_7_sports_2_bikers.jpg", "genre_7_sports_3_stadium.jpg", "genre_7_sports_4_mountain_climbers.jpg", "genre_7_sports_5_runners.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_8 talks
+    fileNames = ["genre_8_talks_1_two_person.jpg", "genre_8_talks_2_interview.jpg", "genre_8_talks_3_interview_girl.jpg", "genre_8_talks_4_podcast_talk.jpg", "genre_8_talks_5_roundtable_talk.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_9 vlog
+    fileNames = ["genre_9_vlog_1_hiking.jpg", "genre_9_vlog_2_photographer.jpg", "genre_9_vlog_3_girl_near_river.jpg", "genre_9_vlog_4_vlogger_mountain.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_10 science
+    fileNames = ["genre_10_science_1_astronaut.jpg", "genre_10_science_3_experiment.jpg", "genre_10_science_5_agriculture.jpg", "genre_10_science_7_outside_earth.jpg", "genre_10_science_2_chemistry.jpg", "genre_10_science_4_antenna.jpg", "genre_10_science_6_cancer_cells.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_11 documentary
+    fileNames = ["genre_11_documentary_1_old_man_face.jpg", "genre_11_documentary_2_street.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_12 movies
+    fileNames = ["genre_12_movies_1_cinema.jpg", "genre_12_movies_2_actor_holding_actress.jpg", "genre_12_movies_3_chicago_theater.jpg", "genre_12_movies_4_movie_set.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_13 journalism
+    fileNames = ["genre_13_journalism_1_girl_rearranging_newspapers.jpg", "genre_13_journalism_2_newspapers.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_14 activism
+    fileNames = ["genre_14_activism_1_black_lives_matter.jpg", "genre_14_activism_3_change_politics_climate.jpg", "genre_14_activism_4_activism.jpg", "genre_14_activism_2_people_protesting.jpg", "genre_14_activism_3_dont_poison_our_water.jpg", "genre_14_activism_5_fashion_is_fucked.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_15 how to do
+    fileNames = ["genre_15_diyhub_1_scissors_pens.jpg", "genre_15_diyhub_2_green_leafed_plants.jpg", "genre_15_diyhub_3_person_holding_black_metal.jpg", "genre_15_diyhub_4_person_molding_vase.jpg", "genre_15_diyhub_5_man_sewing.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_16 other
+    fileNames = ["genre_16_other_1_passion_led_here.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    // genre_17 original
+    fileNames = ["genre_17_original_1.jpg"]
+    allGenreImageFileNames.push(fileNames)
+
+    return allGenreImageFileNames
+}
+
+Videos.getGenreThumbnailUrl = function(genreId) {
+    var genreList = Videos.getGenreList()
+    // get all genre image file names 2d matrix
+    allGenreImageFileNames = Videos.getAllGenreImageFileNames()
+    // get specific genre image file names
+    genreImageFileNames = allGenreImageFileNames[genreId]
+
+
+    // randomly choose a file from the directory
+    id = Math.floor(Math.random() * genreImageFileNames.length)
+    selectedFile = genreImageFileNames[id]
+
+    var imageServerUrl = "http://18.218.250.68:5000"
+    var rootGenreImageDir = imageServerUrl + "/DTube_files/images/genres/"
+    // get genre directory
+    var genreDir = "genre_" + (genreId + 1) + "_" + genreList[genreId]
+
+    // create genre thumbnail url
+    var genreThumbnailUrl = rootGenreImageDir + genreDir + "/" + selectedFile;
+
+    return genreThumbnailUrl
+}
+
+Videos.getAllGenreThumbnailUrls = function() {
+    var genreList = Videos.getGenreList()
+    var allGenreThumbnailUrls = {}
+
+    for(var i=0; i<genreList.length; i++) {
+        var genreName = genreList[i]
+        allGenreThumbnailUrls[genreName] = Videos.getGenreThumbnailUrl(i)
+    }
+
+    return allGenreThumbnailUrls
+}
+
 Videos.getThumbnailUrl = function(video) {
     if (!video || !video.json)
         return ''

--- a/client/css/home.css
+++ b/client/css/home.css
@@ -215,6 +215,13 @@
   margin-bottom: 5px;
 }
 
+.genresnapsnap {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 10px;
+}
+
 .verticalvideosnapsnap {
   position: relative;
   height:90px;

--- a/client/views/commons/videos/genreslider.html
+++ b/client/views/commons/videos/genreslider.html
@@ -1,0 +1,8 @@
+<template name='genreslider'>
+  <div class='owl-carousel owl-theme wid-ful'>
+    {{#each this}}
+      {{>genresnapslider}}
+    {{/each}}
+  </div>
+  <div class="ui divider"></div>
+</template>

--- a/client/views/commons/videos/genreslider.js
+++ b/client/views/commons/videos/genreslider.js
@@ -1,0 +1,132 @@
+var carousel = require('owl.carousel')
+
+Template.genreslider.isOnMobile = function () {
+  if (/Mobi/.test(navigator.userAgent)) {
+    return true;
+  }
+}
+
+Template.genreslider.rendered = function (first, second) {
+  var random = Template.publish.randomPermlink(10)
+  this.firstNode.id = random
+  Template.genreslider.createSlider(random, this.data.length)
+  $(this.firstNode).find('.dropdown').dropdown({});
+  Template.settingsdropdown.nightMode();
+}
+
+Template.genreslider.createSlider = function (elemId,itemCount) {
+  if (Template.genreslider.isOnMobile() == true) {
+    $("#" + elemId).owlCarousel({
+      loop: true,
+      margin: 2,
+      nav: true,
+      navText: ["<i class='chevron left icon semanticui-nextprev-icon'></i>","<i class='chevron right icon semanticui-nextprev-icon'></i>"],
+      items: 10,
+      slideBy: 2,
+      dots: false,
+      lazyLoad: true,
+      responsiveClass: true,
+      responsive: {
+        299: {
+          items: 2,
+          nav: false,
+          slideBy: 2,
+          loop: itemCount > 2
+        },
+        499: {
+          items: 3,
+          nav: false,
+          slideBy: 2,
+          loop: itemCount > 3
+        },
+        699: {
+         items: 3,
+         slideBy: 2,
+        nav: true,
+        loop: itemCount > 3
+       },
+       854: {
+         items: 4,
+         slideBy: 2,
+         nav: true,
+         loop: itemCount > 4
+       },
+       1060: {
+         items: 5,
+         slideBy: 2,
+         nav: true,
+         loop: itemCount > 5
+       }
+      }
+    });
+  }
+  else {
+    $("#" + elemId).owlCarousel({
+      loop: true,
+      margin: 2,
+      items: 10,
+      slideBy: 3,
+      autoWidth: true,
+      responsiveBaseElement: document.getElementsByClassName('ui container'),
+      nav: true,
+      navText: ["<i class='chevron left icon semanticui-nextprev-icon'></i>","<i class='chevron right icon semanticui-nextprev-icon'></i>"],
+      animateOut: 'slideOutDown',
+      animateIn: 'flipInX',
+      dots: false,
+      lazyLoad: true,
+      //autoplay: 6000,
+      //autoplayTimeout: 100000,
+      //autoplayHoverPause: true,
+      responsiveClass: true,
+      responsive: {
+        211: {
+           items: 1,
+           slideBy: 1,
+           nav: false,
+           loop: itemCount > 1
+         },
+        399: {
+           items: 2,
+           slideBy: 2,
+           nav: false,
+           loop: itemCount > 2
+         },
+        642: {
+          items: 3,
+          slideBy: 2,
+          nav: true,
+          loop: itemCount > 3
+        },
+        854: {
+          items: 4,
+          slideBy: 2,
+          nav: true,
+          loop: itemCount > 4
+        },
+        1060: {
+          items: 2, //5,
+          slideBy: 2,
+          nav: true,
+          loop: itemCount > 5
+        },
+        1272: {
+          items: 10,
+          slideBy: 3,
+          nav: true,
+          loop: itemCount > 6
+        },
+        1484: {
+          items: 10,//7,
+          slideBy: 3,
+          nav: true,
+          loop: itemCount > 7
+        }
+      }
+    });
+    //$("#" + elemId).trigger('play.owl.autoplay',[5000]);
+  }
+}
+
+Template.genreslider.refreshSlider = function () {
+  window.dispatchEvent(new Event('resize'))
+}

--- a/client/views/commons/videos/genresnapslider.html
+++ b/client/views/commons/videos/genresnapslider.html
@@ -1,0 +1,17 @@
+<template name='genresnapslider'>
+  {{#unless isVideoHidden this}}
+  <div class='genresnapsnap'>
+    <div class='genresnaptitle'>
+      <a href='/t/{{json.genreName}}'>
+        <h3 style="text-align:center;">{{json.genreName}}</h3>
+      </a>
+      <a href='/t/{{json.genreName}}' title='{{json.title}}'>
+        <div id='snaphover' class='genresnapsnap'>
+          <img id="genresnapimg" class="sprite owl-lazy" data-src="{{json.thumbnailUrl}}" width="100%" height="100%" alt="" >
+        </div>
+      </a>
+    </div>
+    {{ticker}}
+  </div>
+  {{/unless}}
+</template>

--- a/client/views/commons/videos/genresnapslider.js
+++ b/client/views/commons/videos/genresnapslider.js
@@ -1,0 +1,33 @@
+Template.genresnapslider.events({
+  'click .addwatchlater': function () {
+    WatchLater.upsert({_id: this._id},this)
+    event.preventDefault()
+  },
+  'click .watchlater': function () {
+    WatchLater.remove(this._id)
+    event.preventDefault()
+  },
+  'click #remove': function () {
+    WatchLater.remove(this._id)
+    event.preventDefault()
+  }
+})
+
+Template.genresnapslider.helpers({
+  isInWatchLater: function() {
+    return  WatchLater.find({_id: this._id}).fetch()
+  }
+})
+
+Template.genresnapslider.rendered = function () {
+  Template.settingsdropdown.nightMode();
+  $(this.firstNode.nextSibling).find('#snapload').addClass('loaded');
+  $('.retweet.icon.reblogged')
+  .popup({
+    inline     : true,
+    hoverable  : true,
+  })
+;
+}
+
+

--- a/client/views/pages/home/home.html
+++ b/client/views/pages/home/home.html
@@ -1,6 +1,14 @@
 <template name='home'>
-  {{#if isOnMobile}}
+    {{#if isOnMobile}}
     <div style="margin-left:auto;margin-right:auto;margin-top:0px;max-width: 642px;padding-left:5px;padding-right:5px;" class="ui content">
+        {{#if genres}}
+        <div class="ui left aligned grid" style="margin-bottom:0rem;margin-left:0rem;margin-right:0rem;">
+          <div class="left floated left aligned ten wide column block-header" style="padding-left:0px;">
+            <h2>{{ translate 'HOME_TITLE_GENRES'}}</h2>
+          </div>
+        </div>
+        {{> genreslider genres}}
+        {{/if}}
         {{#if feedVideos}}
         <div class="ui left aligned grid" style="margin-bottom:0rem;margin-left:0rem;margin-right:0rem;">
           <div class="left floated left aligned ten wide column block-header" style="padding-left:0px;">
@@ -61,8 +69,16 @@
           {{> videoslider neighborhood}}
         {{/if}}
     </div>
-  {{else}}
+    {{else}}
     <div  class="ui container">
+        {{#if genres}}
+          <div class="ui left aligned grid" style="margin-bottom:0rem;margin-left:0rem;margin-right:0rem;">
+            <div class="left floated left aligned ten wide column block-header" style="padding-left:0px;">
+              <h2>{{ translate 'HOME_TITLE_GENRES'}}</h2>
+            </div>
+          </div>
+          {{> genreslider genres}}
+        {{/if}}
         {{#if feedVideos}}
         <div class="ui left aligned grid" style="margin-bottom:0rem;margin-left:0rem;margin-right:0rem;">
           <div class="left floated left aligned ten wide column block-header" style="padding-left:0px;">

--- a/client/views/pages/home/home.js
+++ b/client/views/pages/home/home.js
@@ -6,6 +6,10 @@ Template.home.helpers({
     if (!Session.get('watchAgainLoaded')) return []
     return WatchAgain.find({}, {limit: sliderMaxSize}).fetch()
   },
+  genres: function () {
+    CarouselVideoSliderType = "genres"
+    return Videos.getGenres()
+  },
   newVideos: function () {
     return Videos.find({ source: 'chainByCreated', "json.hide": {$ne: 1} }, {limit: sliderMaxSize}).fetch()
   },

--- a/public/DTube_files/lang/en/en-US.json
+++ b/public/DTube_files/lang/en/en-US.json
@@ -93,6 +93,7 @@
     "GOLIVE_GET_STREAM_KEY": "Get Stream Key",
     "GOLIVE_STREAM_URL": "Stream URL",
     "GOLIVE_STREAM_KEY": "Stream Key",
+    "HOME_TITLE_GENRES": "Expore Videos",
     "HOME_TITLE_FEED_VIDEOS": "Subscribed Feed",
     "HOME_TITLE_HOT_VIDEOS": "Hot Videos",
     "HOME_TITLE_TRENDING_VIDEOS": "Trending Videos",


### PR DESCRIPTION
This allows a category/genre strip on the front page for exploring some major video categories. Currently each genre links to corresponding tag page, but in future, can be updated by updating how we categorize videos. For example, multiple tags like art, artistic, draw, paint can be/should be categorized under the "art" genre etc.