### PR TITLE
External thumbnail image url option added

### DIFF
--- a/client/views/pages/publish/publish.html
+++ b/client/views/pages/publish/publish.html
@@ -50,6 +50,10 @@
                             </div>
                         </div>
                         {{/unless}}
+                        <div class="field publishfield">
+                            <label>{{ translate 'THUMBNAIL_URL_EXTERNAL'}}</label>
+                            <input id="thumbnailUrlExternal" type="text" name="thumbnailUrlExternal" placeholder="{{ translate 'THUMBNAIL_URL_EXTERNAL_PLACEHOLDER'}}" value="{{json.thumbnailUrlExternal}}">
+                        </div>
                     </form>
                 </div>
                 

--- a/client/views/pages/publish/publish.js
+++ b/client/views/pages/publish/publish.js
@@ -168,13 +168,17 @@ Template.publish.events({
         Session.set('tmpVideo', {})
         UserSettings.set('tmpVideo', {})
     },
-    'change #uploadTitle, change #uploadDescription, change #tagDropdown, change #visibilityDropdown, change #inputNsfw, change #inputOC, change #inputDuration': function() {
+    'change #uploadTitle, change #uploadDescription, change #thumbnailUrlExternal,change #tagDropdown, change #visibilityDropdown, change #inputNsfw, change #inputOC, change #inputDuration': function() {
         var tmpVideo = Session.get('tmpVideo')
         tmpVideo.json.title = $('#uploadTitle')[0].value
         tmpVideo.json.desc = $('#uploadDescription')[0].value
         if (!Session.get('tmpVideoEdit')) {
             tmpVideo.json.tag = $('#tagDropdown')[0].value
             tmpVideo.json.dur = $('#inputDuration')[0].value
+        }
+        if ($('#thumbnailUrlExternal')[0]) {
+            tmpVideo.json.thumbnailUrlExternal = $('#thumbnailUrlExternal')[0].value
+            tmpVideo.json.thumbnailUrl = tmpVideo.json.thumbnailUrlExternal
         }
 
         tmpVideo.json.hide = parseInt($('#visibilityDropdown')[0].value)
@@ -188,6 +192,7 @@ Template.publish.events({
             tmpVideo.json.oc = 0
         Session.set('tmpVideo', tmpVideo)
         UserSettings.set('tmpVideo', tmpVideo)
+        Template.player.reset()
     },
     'change #inputSteemMarkdown, change #inputSteemPowerup': function() {
         var tmpVideo = Session.get('tmpVideo')

--- a/client/views/pages/upload/uploadform/uploadform.js
+++ b/client/views/pages/upload/uploadform/uploadform.js
@@ -107,7 +107,11 @@ Template.uploadformsubmit.events({
       video.json.ipfs.videohash = $('input[name=videohash]')[0].value
       video.json.ipfs.spritehash = $('input[name=spritehash]')[0].value
       video.json.ipfs.snaphash = $('input[name=snaphash]')[0].value
-      video.json.thumbnailUrl = 'https://snap1.d.tube/ipfs/' + $('input[name=snaphash]')[0].value
+      if (!$('input[name=thumbnailUrlExternal]')[0].value) {
+        video.json.thumbnailUrl = $('input[name=thumbnailUrlExternal]')[0].value 
+      } else {
+        video.json.thumbnailUrl = 'https://snap1.d.tube/ipfs/' + $('input[name=snaphash]')[0].value
+      }
 
       if ($('input[name=video240hash]')[0].value) video.json.ipfs.video240hash = $('input[name=video240hash]')[0].value
       if ($('input[name=video480hash]')[0].value) video.json.ipfs.video480hash = $('input[name=video480hash]')[0].value

--- a/public/DTube_files/lang/en/en-US.json
+++ b/public/DTube_files/lang/en/en-US.json
@@ -239,6 +239,8 @@
     "TAGS_VERY_SHORT": "Very Short ( < 5 minutes)",
     "TAGS_SHORT_SELECTED": "Short",
     "TAGS_VERY_SHORT_SELECTED": "Very Short",
+    "THUMBNAIL_URL_EXTERNAL": "Thumbnail URL (3rd Party)",
+    "THUMBNAIL_URL_EXTERNAL_PLACEHOLDER": "Add external 3rd Party thumbnail URL instead of adding thumbnail below",
     "TOPBAR_LOGIN": "Login",
     "TOPBAR_PLACEHOLDER_SEARCH_VIDEOS": "Search",
     "TOPBAR_DTC_EXPLAIN": "DTUBE Coins - Hold more of it to generate more Voting Power. You can burn it to promote your videos and comments.",


### PR DESCRIPTION
External (3rd party) thumbnail Image URL can be provided instead of uploading thumbnail image through IPFS uploader.

Before setting the input of 3rd party thumbnail, the "Add Thumbnail" under "Files" causes the thumbnail error.

<img width="1770" alt="Screen Shot 2021-08-21 at 6 08 00 PM" src="https://user-images.githubusercontent.com/2281405/130337025-4b1c2406-2b90-4b16-95db-421bb703561b.png">

After adding the 3rd party URL, session variable is set and no longer "Add Thumbnail" is required.

<img width="1779" alt="Screen Shot 2021-08-21 at 6 08 13 PM" src="https://user-images.githubusercontent.com/2281405/130337041-097fd53a-daf2-4c82-bbc4-451ab2d8b166.png">


Tested with this video upload:
https://d.tube/#!/v/brishtiteveja0595/QmS7A24NNP5mkU5Xuh6sVVGxTXpoLzUT7sYKryAT5T1xys
with Thumbnail image URL:
https://i.imgur.com/DyJ2WUx.png

Correctly showing on channel: 

<img width="992" alt="Screen Shot 2021-08-21 at 6 16 32 PM" src="https://user-images.githubusercontent.com/2281405/130337096-71e12e40-0327-4f53-897b-19aa4b54e1de.png">
