### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -107,7 +107,7 @@ Meteor.startup(function(){
       sources.push(scripts[i].src)
 
   if (sources.length == 1)
-    Session.set('buildVersion', sources[0].split('/')[sources[0].split('/').length-1].substr(0, 8))
+    Session.set('buildVersion', sources[0].split('/')[sources[0].split('/').length-1].slice(0, 8))
   else Session.set('buildVersion', 'dev')
 
   // ethereum metamask

--- a/client/broadcast.js
+++ b/client/broadcast.js
@@ -583,12 +583,12 @@ broadcast = {
             if (Users.findOne({ username: Session.get('activeUsernameSteem'), network: 'steem' }).type == 'keychain') {
                 if (!steem_keychain) return cb('LOGIN_ERROR_KEYCHAIN_NOT_INSTALLED')
                 steem_keychain.requestVerifyKey(Session.get('activeUsernameSteem'), memo, 'Posting', (response) => {
-                    cb(response.error, response.result.substr(1))
+                    cb(response.error, response.result.slice(1))
                 })
                 return
             }
             let wif = Users.findOne({ username: Session.get('activeUsernameSteem'), network: 'steem' }).privatekey
-            let decoded = steem.memo.decode(wif, memo).substr(1)
+            let decoded = steem.memo.decode(wif, memo).slice(1)
             cb(null, decoded)
         }
     },
@@ -1174,12 +1174,12 @@ broadcast = {
             if (Users.findOne({ username: Session.get('activeUsernameHive'), network: 'hive' }).type == 'keychain') {
                 if (!hive_keychain) return cb(translate('LOGIN_ERROR_HIVE_KEYCHAIN_NOT_INSTALLED'))
                 hive_keychain.requestVerifyKey(Session.get('activeUsernameHive'), memo, 'Posting', (response) => {
-                    cb(response.error, response.result.substr(1))
+                    cb(response.error, response.result.slice(1))
                 })
                 return
             }
             let wif = Users.findOne({ username: Session.get('activeUsernameHive'), network: 'hive' }).privatekey
-            let decoded = hive.memo.decode(wif, memo).substr(1)
+            let decoded = hive.memo.decode(wif, memo).slice(1)
             cb(null, decoded)
         }
     },
@@ -1305,12 +1305,12 @@ broadcast = {
           if (Users.findOne({ username: Session.get('activeUsernameBlurt'), network: 'blurt' }).type == 'keychain') {
               if (!blurt_keychain) return cb(translate('LOGIN_ERROR_BLURT_KEYCHAIN_NOT_INSTALLED'))
               blurt_keychain.requestVerifyKey(Session.get('activeUsernameBlurt'), memo, 'Posting', (response) => {
-                  cb(response.error, response.result.substr(1))
+                  cb(response.error, response.result.slice(1))
               })
               return
           }
           let wif = Users.findOne({ username: Session.get('activeUsernameBlurt'), network: 'blurt' }).privatekey
-          let decoded = hive.memo.decode(wif, memo).substr(1)
+          let decoded = hive.memo.decode(wif, memo).slice(1)
           cb(null, decoded)
       }
     }

--- a/client/lib/definitions/modules/dropdown.js
+++ b/client/lib/definitions/modules/dropdown.js
@@ -190,7 +190,7 @@ $.fn.dropdown = function(parameters) {
 
         create: {
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2, 8);
+            id = (Math.random().toString(16) + '000000000').slice(2, 10);
             elementNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           },
@@ -2287,7 +2287,7 @@ $.fn.dropdown = function(parameters) {
             var
               length = module.get.query().length
             ;
-            $search.val( text.substr(0, length));
+            $search.val( text.slice(0, length));
           },
           scrollPosition: function($item, forceScroll) {
             var

--- a/client/lib/definitions/modules/modal.js
+++ b/client/lib/definitions/modules/modal.js
@@ -136,7 +136,7 @@ $.fn.modal = function(parameters) {
             $dimmer = $dimmable.dimmer('get dimmer');
           },
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2,8);
+            id = (Math.random().toString(16) + '000000000').slice(2,10);
             elementEventNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           }
@@ -216,7 +216,7 @@ $.fn.modal = function(parameters) {
 
         get: {
           id: function() {
-            return (Math.random().toString(16) + '000000000').substr(2,8);
+            return (Math.random().toString(16) + '000000000').slice(2,10);
           }
         },
 

--- a/client/lib/definitions/modules/popup.js
+++ b/client/lib/definitions/modules/popup.js
@@ -304,7 +304,7 @@ $.fn.popup = function(parameters) {
         },
 
         createID: function() {
-          id = (Math.random().toString(16) + '000000000').substr(2, 8);
+          id = (Math.random().toString(16) + '000000000').slice(2, 10);
           elementNamespace = '.' + id;
           module.verbose('Creating unique id for element', id);
         },

--- a/client/lib/definitions/modules/sidebar.js
+++ b/client/lib/definitions/modules/sidebar.js
@@ -118,7 +118,7 @@ $.fn.sidebar = function(parameters) {
 
         create: {
           id: function() {
-            id = (Math.random().toString(16) + '000000000').substr(2,8);
+            id = (Math.random().toString(16) + '000000000').slice(2,10);
             elementNamespace = '.' + id;
             module.verbose('Creating unique id for element', id);
           }

--- a/client/translate.js
+++ b/client/translate.js
@@ -20,7 +20,7 @@ window.loadLangAuto = function(cb) {
   });
 }
 window.loadJsonTranslate = function(culture, cb = function(){}){
-  if (culture.substr(0,2) == 'en') {
+  if (culture.slice(0,2) == 'en') {
     Session.set('jsonTranslate', null)
     UserSettings.set('language', null)
     cb()
@@ -54,7 +54,7 @@ function translate(code){
   }
 
   if(!found){
-    if (culture.substr(0,2) != 'en')
+    if (culture.slice(0,2) != 'en')
       console.log('have not found translation in ' + culture + ' :'+code);
     if (jsonTranslateDef) {
       for(var key in jsonTranslateDef){
@@ -105,7 +105,7 @@ function getCultureAuto(){
       if (key === cult) return key
 
     for(var key in Meteor.settings.public.lang)
-      if (cult.substr(0,2) === key.substr(0,2)) return key;
+      if (cult.slice(0,2) === key.slice(0,2)) return key;
 
   }
   return culture;

--- a/client/views/pages/publish/addfile/sub/addsubtitle.js
+++ b/client/views/pages/publish/addfile/sub/addsubtitle.js
@@ -47,7 +47,7 @@ Template.addsubtitle.events({
         var reader = new FileReader();
         reader.onload = function(){
           console.log(reader.result);
-          if (reader.result.substr(0,6) != 'WEBVTT')
+          if (reader.result.slice(0,6) != 'WEBVTT')
             $('#subtitleText')[0].innerHTML = srt2webvtt(reader.result)
           else
           $('#subtitleText')[0].innerHTML = reader.result

--- a/client/views/pages/upload/uploadfileform/uploadformsubtitles.js
+++ b/client/views/pages/upload/uploadfileform/uploadformsubtitles.js
@@ -50,7 +50,7 @@ Template.uploadformsubtitles.events({
         var reader = new FileReader();
         reader.onload = function(){
           console.log(reader.result);
-          if (reader.result.substr(0,6) != 'WEBVTT')
+          if (reader.result.slice(0,6) != 'WEBVTT')
             $('#subtitleText')[0].innerHTML = srt2webvtt(reader.result)
           else
           $('#subtitleText')[0].innerHTML = reader.result


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.