### PR TITLE
Updated with new signup link

### DIFF
--- a/client/views/pages/login/loginavalon/loginavalon.html
+++ b/client/views/pages/login/loginavalon/loginavalon.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="ui message" style="margin-top:20px;">
                     {{ translate 'LOGIN_LINK_NO_ACCOUNT'}}
-                    <a href="https://signup.d.tube" target="_blank"> 
+                    <a href="https://signup.dtube.fso.ovh" target="_blank"> 
                         {{ translate 'LOGIN_LINK_SIGN_UP_ON'}} d.tube</a>
                     <br />
                 </div>


### PR DESCRIPTION
#361
This edit will replace the URL that isn't online anymore with my new singup URL.
So it will make less confusion about the (old) signup page not working anymore.