### PR TITLE
Solves the missing image issue in slidebar.

### DIFF
--- a/client/views/commons/videos/videosnapslider.html
+++ b/client/views/commons/videos/videosnapslider.html
@@ -35,7 +35,7 @@
             <i class="icon photo nosnap" style="font-size:28px;margin-top:40px;"></i>
             <div class="ui text nosnap" style="margin-top:10px;">{{translate 'SNAP_MISSING_IMAGE'}}</div>
           </div> 
-        <img id="snapimg" class="sprite owl-lazy" src="{{json.thumbnailUrl}}" width="100%" height="100%" style="max-height:118px;" alt="" onerror="Template.videosnap.fallback(this)">
+        <img id="snapimg" class="sprite" src="{{json.thumbnailUrl}}" width="100%" height="100%" style="max-height:118px;" alt="" onerror="Template.videosnap.fallback(this)">
       </div>
         <br />
       </div>


### PR DESCRIPTION

<img width="1240" alt="Screenshot 2023-01-08 at 11 17 41 AM" src="https://user-images.githubusercontent.com/2281405/211209770-0a332158-084b-4ad5-b7de-23cae15df614.png">

This solves the missing image issue on frontpage that I experience on brave/chrome browser while scrolling. Please test and merge if you can verify.