### PR TITLE
Patch ipfs.d.tube offline

### DIFF
--- a/client/collections/videos.js
+++ b/client/collections/videos.js
@@ -1048,7 +1048,7 @@ Videos.getOverlayUrl = function(video) {
     if (video.json.files && video.json.files.btfs && video.json.files.btfs.img && video.json.files.btfs.img["360"])
         return 'https://btfs.d.tube/btfs/' + video.json.files.btfs.img["360"]
     if (video.json.files && video.json.files.ipfs && video.json.files.ipfs.img && video.json.files.ipfs.img["360"])
-        return 'https://ipfs.d.tube/ipfs/' + video.json.files.ipfs.img["360"]
+        return 'https://ipfs.io/ipfs/' + video.json.files.ipfs.img["360"]
     if (video.json.files && video.json.files.youtube)
         return 'https://i.ytimg.com/vi/' + video.json.files.youtube + '/hqdefault.jpg'
     return ''
@@ -1062,12 +1062,12 @@ Videos.getThumbnailUrl = function(video) {
     if (video.json.files && video.json.files.btfs && video.json.files.btfs.img && video.json.files.btfs.img["118"])
         return 'https://btfs.d.tube/btfs/' + video.json.files.btfs.img["118"]
     if (video.json.files && video.json.files.ipfs && video.json.files.ipfs.img && video.json.files.ipfs.img["118"])
-        return 'https://ipfs.d.tube/ipfs/' + video.json.files.ipfs.img["118"]
+        return 'https://ipfs.io/ipfs/' + video.json.files.ipfs.img["118"]
     if (video.json.files && video.json.files.youtube)
         return 'https://i.ytimg.com/vi/' + video.json.files.youtube + '/mqdefault.jpg'
 
-    if (video.json.ipfs && video.json.ipfs.snaphash) return 'https://ipfs.d.tube/ipfs/' + video.json.ipfs.snaphash
-    if (video.json.info && video.json.info.snaphash) return 'https://ipfs.d.tube/ipfs/' + video.json.info.snaphash
+    if (video.json.ipfs && video.json.ipfs.snaphash) return 'https://ipfs.io/ipfs/' + video.json.ipfs.snaphash
+    if (video.json.info && video.json.info.snaphash) return 'https://ipfs.io/ipfs/' + video.json.info.snaphash
         // console.log('Found video with no thumbnail!!', video)
     return ''
 }
@@ -1106,7 +1106,7 @@ Videos.convertToNewFormat = function(oldJson, video) {
         title: oldJson.info.title,
         description: oldJson.content.description,
         duration: oldJson.info.duration,
-        thumbnailUrl: 'https://ipfs.d.tube/ipfs/' + oldJson.info.snaphash,
+        thumbnailUrl: 'https://ipfs.io/ipfs/' + oldJson.info.snaphash,
         ipfs: {
             snaphash: oldJson.info.snaphash,
             spritehash: oldJson.info.spritehash,

--- a/client/settings.js
+++ b/client/settings.js
@@ -19,7 +19,6 @@ Meteor.settings.public = {
     "AvalonAPINodes": [
       "https://avalon.d.tube",
       "https://api.avalonblocks.com",
-      "https://avalon.sagarkothari88.one",
       "https://dtube.fso.ovh",
       "https://dtube.tekraze.com",
       "http://localhost:3001",

--- a/client/settings.js
+++ b/client/settings.js
@@ -5,7 +5,6 @@ Meteor.settings.public = {
     "loadLimit": 50,
     "displayNodes": [
       // "https://snap1.d.tube",
-      "https://ipfs.d.tube",
       "https://video.oneloveipfs.com",
       "https://ipfs.io",
       "https://ipfs.infura.io",


### PR DESCRIPTION
Removed reference to ipfs.d.tube server, which went offline a long time ago.
Removed an API node that's offline, and not likely to come back online anytime soon.